### PR TITLE
Improve admin layout and login

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@200..800&family=PT+Mono&family=Unbounded:wght@100..900&display=swap"
+      rel="stylesheet"
+    />
     <title>Vite + React + TS</title>
   </head>
   <body>

--- a/admin/src/components/Layout.tsx
+++ b/admin/src/components/Layout.tsx
@@ -37,40 +37,42 @@ const Layout = () => {
 
   return (
     <div className="min-h-screen flex flex-col">
-      <header className="bg-gray-800 text-white p-4 flex items-center justify-between">
-        <h1
-          className="text-xl font-bold cursor-pointer"
-          onClick={() => navigate("/")}
-        >
-          Admin Panel
-        </h1>
+      <header className="bg-gray-800 text-white p-4">
+        <div className="flex items-center justify-between w-full max-w-7xl mx-auto">
+          <h1
+            className="text-xl font-bold cursor-pointer"
+            onClick={() => navigate("/")}
+          >
+            Admin Panel
+          </h1>
 
-        <nav className="space-x-4">
-          {links.map(({ to, label }) => (
-            <button
-              key={to}
-              onClick={() => navigate(to)}
-              className={`px-3 py-1 rounded ${
-                location.pathname === to ? "bg-gray-700" : "hover:bg-gray-700"
-              }`}
-            >
-              {label}
-            </button>
-          ))}
-        </nav>
+          <nav className="space-x-4">
+            {links.map(({ to, label }) => (
+              <button
+                key={to}
+                onClick={() => navigate(to)}
+                className={`px-3 py-1 rounded ${
+                  location.pathname === to ? "bg-gray-700" : "hover:bg-gray-700"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </nav>
 
-        <button
-          onClick={() => {
-            localStorage.removeItem("role");
-            navigate("/login");
-          }}
-          className="bg-red-600 px-3 py-1 rounded hover:bg-red-700"
-        >
-          Выйти
-        </button>
+          <button
+            onClick={() => {
+              localStorage.removeItem("role");
+              navigate("/login");
+            }}
+            className="bg-red-600 px-3 py-1 rounded hover:bg-red-700"
+          >
+            Выйти
+          </button>
+        </div>
       </header>
 
-      <main className="flex-grow bg-gray-100 p-6">
+      <main className="flex-grow bg-gray-100 p-6 w-full max-w-7xl mx-auto">
         <Outlet />
       </main>
 

--- a/admin/src/index.css
+++ b/admin/src/index.css
@@ -10,7 +10,7 @@
   --font-body: 'Manrope', sans-serif;
   --font-mono: 'PT Mono', monospace;
 
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: var(--font-body), sans-serif;
   line-height: 1.5;
   font-weight: 400;
 

--- a/admin/src/pages/LoginPage.tsx
+++ b/admin/src/pages/LoginPage.tsx
@@ -26,16 +26,20 @@ export default function LoginPage() {
       const data = await res.json();
       localStorage.setItem("token", data.token);
       navigate("/users");
-    } catch (err: any) {
-      setError(err.message);
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("Ошибка входа");
+      }
     }
   };
 
   return (
-    <div className="flex h-screen w-screen items-center justify-center bg-gray-50 p-6">
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-8 px-4">
       <form
         onSubmit={handleLogin}
-        className="w-full max-w-sm bg-white rounded-xl shadow-lg border border-gray-200 p-10 flex flex-col gap-8"
+        className="w-full max-w-md bg-white rounded-xl shadow-lg border border-gray-200 p-10 flex flex-col gap-8"
         style={{ minWidth: 320 }}
       >
         <h2 className="text-3xl font-semibold text-center text-gray-900 mb-4">

--- a/admin/src/pages/Users.tsx
+++ b/admin/src/pages/Users.tsx
@@ -105,8 +105,12 @@ export default function UsersPage() {
       const data = await res.json();
       setUsers(data);
       setError("");
-    } catch (err: any) {
-      setError(err.message || "Ошибка загрузки пользователей");
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message || "Ошибка загрузки пользователей");
+      } else {
+        setError("Ошибка загрузки пользователей");
+      }
       console.error(err);
     }
   };
@@ -161,8 +165,12 @@ export default function UsersPage() {
       fetchUsers();
       markClean();
       setError("");
-    } catch (err: any) {
-      setError(err.message || "Ошибка добавления пользователя");
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message || "Ошибка добавления пользователя");
+      } else {
+        setError("Ошибка добавления пользователя");
+      }
       console.error(err);
     }
   };
@@ -178,8 +186,12 @@ export default function UsersPage() {
         throw new Error("Ошибка удаления пользователя: " + res.status);
       setUsers((prev) => prev.filter((u) => u.id !== id));
       setError("");
-    } catch (err: any) {
-      setError(err.message || "Ошибка удаления пользователя");
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message || "Ошибка удаления пользователя");
+      } else {
+        setError("Ошибка удаления пользователя");
+      }
       console.error(err);
     }
   };


### PR DESCRIPTION
## Summary
- tweak layout widths for better centering
- hook up Google fonts via index.html
- use body font variable in base CSS
- refine login form layout
- replace `any` in error handlers with safer `unknown`

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687ff3f50bb08324b5efcb61cf8f1409