### PR TITLE
Refine admin UI

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -7,9 +7,17 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
+      rel="preload"
       href="https://fonts.googleapis.com/css2?family=Manrope:wght@200..800&family=PT+Mono&family=Unbounded:wght@100..900&display=swap"
-      rel="stylesheet"
+      as="style"
+      onload="this.onload=null;this.rel='stylesheet'"
     />
+    <noscript>
+      <link
+        href="https://fonts.googleapis.com/css2?family=Manrope:wght@200..800&family=PT+Mono&family=Unbounded:wght@100..900&display=swap"
+        rel="stylesheet"
+      />
+    </noscript>
     <title>Vite + React + TS</title>
   </head>
   <body>

--- a/admin/src/components/Layout.tsx
+++ b/admin/src/components/Layout.tsx
@@ -55,8 +55,8 @@ const Layout = () => {
   }
 
   return (
-    <div className="min-h-screen flex flex-col">
-      <header className="bg-gray-800 text-white p-4 flex items-center justify-between">
+    <div className="min-h-screen flex flex-col font-sans">
+      <header className="bg-gray-800 text-white h-16 px-6 flex items-center justify-between">
         <h1
           className="text-xl font-bold cursor-pointer"
           onClick={() => navigate("/")}
@@ -90,11 +90,13 @@ const Layout = () => {
         </button>
       </header>
 
-      <main className="flex-grow bg-gray-100 p-6">
-        <Outlet />
+      <main className="flex-grow bg-gray-100">
+        <div className="max-w-7xl mx-auto p-6">
+          <Outlet />
+        </div>
       </main>
 
-      <footer className="bg-gray-800 text-white p-4 text-center">
+      <footer className="bg-gray-800 text-white h-12 flex items-center justify-center text-sm">
         © 2025 nabludatel.core
       </footer>
     </div>

--- a/admin/src/pages/LoginPage.tsx
+++ b/admin/src/pages/LoginPage.tsx
@@ -36,10 +36,10 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-8 px-4">
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
       <form
         onSubmit={handleLogin}
-        className="w-full max-w-md bg-white rounded-xl shadow-lg border border-gray-200 p-10 flex flex-col gap-8"
+        className="mx-auto w-full max-w-md bg-white rounded-xl shadow-lg border border-gray-200 p-10 flex flex-col gap-8 font-sans"
         style={{ minWidth: 320 }}
       >
         <h2 className="text-3xl font-semibold text-center text-gray-900 mb-4">

--- a/admin/src/pages/SitesPage.tsx
+++ b/admin/src/pages/SitesPage.tsx
@@ -48,7 +48,7 @@ export default function SitesPage() {
 
       const data = await res.json();
       setSites(data);
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error("Ошибка при загрузке сайтов:", err);
       setError(err.message || "Не удалось загрузить список сайтов");
     } finally {
@@ -97,7 +97,7 @@ export default function SitesPage() {
         )
       );
       alert(`Статус сайта ${siteId} изменен на ${newStatus}`); // Временное уведомление
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error("Ошибка при изменении статуса:", err);
       alert(err.message || "Не удалось изменить статус сайта"); // Временное уведомление
     }
@@ -112,7 +112,7 @@ export default function SitesPage() {
   }
 
   return (
-    <div className="p-6 max-w-4xl mx-auto">
+    <div className="container mx-auto max-w-4xl p-6 font-sans">
       <h1 className="text-3xl font-bold mb-6 text-gray-800">
         Управление Сайтами
       </h1>
@@ -124,19 +124,19 @@ export default function SitesPage() {
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50">
               <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">
                   Название
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">
                   Домен
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">
                   План
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">
                   Статус
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">
                   Действия
                 </th>
               </tr>
@@ -157,8 +157,8 @@ export default function SitesPage() {
                     <span
                       className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
                         site.status === "active"
-                          ? "bg-green-100 text-green-800"
-                          : "bg-red-100 text-red-800"
+                          ? "bg-green-50 text-green-700"
+                          : "bg-red-50 text-red-700"
                       }`}
                     >
                       {site.status === "active" ? "Активен" : "Отключен"}


### PR DESCRIPTION
## Summary
- center login form, limit width and use consistent fonts
- refine layout spacing and add container for centered content
- soften status colors and adjust table typography
- preload fonts for smoother rendering

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687fffb3a9948324a0d162429df6630d