### PR TITLE
Add version/date logs for services

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -2,9 +2,10 @@
   "name": "admin",
   "private": true,
   "version": "0.0.0",
+  "lastUpdated": "2025-07-25T05:18:00+0500",
   "type": "module",
   "scripts": {
-    "dev": "node ./print-admin-banner.js && vite",
+    "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/admin/print-admin-banner.js
+++ b/admin/print-admin-banner.js
@@ -1,3 +1,4 @@
+const pkg = require('./package.json');
 setTimeout(() => {
   console.log("\n" + "=".repeat(60));
   console.log("🧠 NABLUДATEL PLATFORM — ADMIN PANEL");
@@ -5,6 +6,8 @@ setTimeout(() => {
   console.log("🖥 Основана на Vite + React + TypeScript.");
   console.log("🔧 Подключение к backend через REST API.");
   console.log("✨ Часть масштабируемой платформы NABLUДATEL, разрабатываемой @intragentt.");
+  console.log(`🕒 Последнее обновление:  ${pkg.lastUpdated}`);
+  console.log(`🧪 Версия билда:          v${pkg.version}`);
   console.log("📬 По вопросам и доступу: https://t.me/intragentt");
   console.log("=".repeat(60) + "\n");
 }, 800);

--- a/admin/tsconfig.node.json
+++ b/admin/tsconfig.node.json
@@ -19,7 +19,11 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "@scripts/*": ["../scripts/*"]
+    }
   },
   "include": ["vite.config.ts"]
 }

--- a/admin/vite.config.ts
+++ b/admin/vite.config.ts
@@ -1,5 +1,21 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import fs from 'fs'
+import path from 'path'
+import { printAdminBanner } from '@scripts/printAdminBanner'
+import { printServerStop } from '@scripts/printServerStop'
+
+const pkgPath = path.resolve(__dirname, 'package.json')
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'))
+printAdminBanner()
+process.on('SIGINT', () => {
+  printServerStop('admin', pkg.lastUpdated, pkg.version)
+  process.exit(0)
+})
+process.on('SIGTERM', () => {
+  printServerStop('admin', pkg.lastUpdated, pkg.version)
+  process.exit(0)
+})
 
 // https://vite.dev/config/
 export default defineConfig({

--- a/apps/site-runner/src/server.ts
+++ b/apps/site-runner/src/server.ts
@@ -2,8 +2,9 @@
 // import "tsconfig-paths/register";
 const path = require("path");
 const fs = require("fs");
+import { printServerStop } from "@scripts/printServerStop";
 
-const pkgPath = path.resolve(__dirname, "../../../../package.json");
+const pkgPath = path.resolve(__dirname, "../package.json");
 const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
 import express from "express";
 import React from "react";
@@ -62,15 +63,17 @@ app.listen(PORT, () => {
   console.log(`📦 Тип:                   SSR / статическая сборка`);
   console.log(`🧩 Рендеринг через:       PageRenderer`);
   console.log(`🕒 Последнее обновление:  ${pkg.lastUpdated}`);
-  console.log(`🧪 Версия билда:          ${pkg.buildVersion}`);
+  console.log(`🧪 Версия билда:          v${pkg.version}`);
   console.log(`📬 Обратная связь:        https://t.me/intragentt`);
   console.log(`🧠 Создан на платформе:   NABLUДATEL PLATFORM`);
   console.log("=".repeat(60) + "\n");
 });
 
 process.on("SIGINT", () => {
-  console.log("\n" + "=".repeat(60));
-  console.log("🛑 Сервер KYANCHIR остановлен вручную.");
-  console.log("============================================================\n");
+  printServerStop("kyanchir", pkg.lastUpdated, pkg.version);
+  process.exit(0);
+});
+process.on("SIGTERM", () => {
+  printServerStop("kyanchir", pkg.lastUpdated, pkg.version);
   process.exit(0);
 });

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -2,6 +2,8 @@
 import express from "express";
 import cors from "cors";
 import path from "path";
+import { printServerStop } from "@scripts/printServerStop";
+import pkg from "./package.json";
 import usersRouter from "./routes/users";
 import uploadRouter from "./routes/upload";
 import authRouter from "./routes/auth";
@@ -52,13 +54,17 @@ app.listen(PORT, () => {
   console.log(`🌐 Сервер запущен на: http://localhost:${PORT}`);
   console.log(`📂 API доступно по адресу: http://localhost:${PORT}/api`);
   console.log(`📸 Загрузка файлов: http://localhost:${PORT}/api/upload`);
+  console.log(`🕒 Последнее обновление:  ${pkg.lastUpdated}`);
+  console.log(`🧪 Версия билда:          v${pkg.version}`);
   console.log(`✉️ Telegram: @intragentt`);
   console.log("=".repeat(60) + "\n");
 });
 
 process.on("SIGINT", () => {
-  console.log("\n" + "=".repeat(60));
-  console.log("🛑 Сервер NABLUДATЕЛЬ остановлен вручную.");
-  console.log("=".repeat(60) + "\n");
+  printServerStop("backend", pkg.lastUpdated, pkg.version);
+  process.exit(0);
+});
+process.on("SIGTERM", () => {
+  printServerStop("backend", pkg.lastUpdated, pkg.version);
   process.exit(0);
 });

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,7 +1,8 @@
 {
     "name": "backend",
-    "version": "0.0.1",
-    "private": true,
+  "version": "0.0.1",
+  "lastUpdated": "2025-07-25T05:18:00+0500",
+  "private": true,
     "scripts": {
       "dev": "tsx index.ts"
     },

--- a/scripts/printAdminBanner.ts
+++ b/scripts/printAdminBanner.ts
@@ -1,4 +1,9 @@
+import fs from "fs";
+import path from "path";
+
 export function printAdminBanner() {
+  const pkgPath = path.resolve(__dirname, "../admin/package.json");
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
   console.log("\n" + "=".repeat(60));
   console.log("🧠 NABLUДATEL PLATFORM — ADMIN PANEL");
   console.log(
@@ -9,6 +14,8 @@ export function printAdminBanner() {
   console.log(
     "✨ Часть масштабируемой платформы NABLUДATEL, разрабатываемой @intragentt."
   );
+  console.log(`🕒 Последнее обновление:  ${pkg.lastUpdated}`);
+  console.log(`🧪 Версия билда:          v${pkg.version}`);
   console.log("📬 По вопросам и доступу: https://t.me/intragentt");
   console.log("=".repeat(60) + "\n");
 }

--- a/scripts/printStartup.ts
+++ b/scripts/printStartup.ts
@@ -1,6 +1,6 @@
-export function printServerStop(name: string, lastUpdated: string, version: string) {
+export function printStartup(name: string, lastUpdated: string, version: string) {
   console.log("\n" + "=".repeat(60));
-  console.log(`🛑 Сервер ${name.toUpperCase()} остановлен.`);
+  console.log(`🚀 ${name.toUpperCase()} ЗАПУЩЕН`);
   console.log(`🕒 Последнее обновление:  ${lastUpdated}`);
   console.log(`🧪 Версия билда:          v${version}`);
   console.log("=".repeat(60) + "\n");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
       "@nabudatel/core": ["packages/core/src"],
       "@nabudatel/core/*": ["packages/core/src/*"],
       "@nabudatel/ui": ["packages/ui/src"],
-      "@nabudatel/ui/*": ["packages/ui/src/*"]
+      "@nabudatel/ui/*": ["packages/ui/src/*"],
+      "@scripts/*": ["scripts/*"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- show build version and date with custom banners
- print startup/shutdown information for admin, backend, and site-runner
- fix imports with `@scripts/*` alias in tsconfig
- add lastUpdated metadata in admin and backend packages

## Testing
- `npx tsc -p backend/tsconfig.json --noEmit` *(fails: Property 'user' does not exist on type Request)*

------
https://chatgpt.com/codex/tasks/task_e_6882d891f5308324acf5dddbd15f91ea