### PR TITLE
Add simple swiper and responsive header

### DIFF
--- a/apps/kyanchir/src/PageRenderer.tsx
+++ b/apps/kyanchir/src/PageRenderer.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 // Импортируем компоненты Header и CatalogContent из пакета UI
-import { Header, CatalogContent } from "../../../packages/ui/src/index";
+import { Header, CatalogContent, SimpleSwiper } from "../../../packages/ui/src/index";
 // Импортируем типы данных Product, Page, Site из пакета Core
 import type { Product, Page, Site } from "../../../packages/core/src/index";
 
@@ -10,6 +10,7 @@ import type { Product, Page, Site } from "../../../packages/core/src/index";
 const componentsMap: { [key: string]: React.ComponentType<any> } = {
   Header: Header,
   CatalogContent: CatalogContent,
+  SimpleSwiper: SimpleSwiper,
 };
 
 // Интерфейс пропсов для PageRenderer

--- a/backend/db/pages.json
+++ b/backend/db/pages.json
@@ -26,6 +26,13 @@
         }
       },
       {
+        "id": "comp-swiper-uuid",
+        "type": "SimpleSwiper",
+        "props": {
+          "slides": ["Слайд 1", "Слайд 2", "Слайд 3"]
+        }
+      },
+      {
         "id": "comp-catalog-uuid",
         "type": "CatalogContent",
         "props": {}

--- a/packages/ui/src/Header.tsx
+++ b/packages/ui/src/Header.tsx
@@ -1,30 +1,63 @@
 import React from "react";
 import Logo from "./icons/Logo";
+import BurgerIcon from "./icons/BurgerIcon";
+import CloseIcon from "./icons/CloseIcon";
+import { NAV_LINKS } from "./config/navigation";
 
 export default function Header() {
   return (
     <>
-      <header className="fixed top-0 left-0 right-0 z-50 w-full h-[72px] border-b border-gray-200 bg-gray-100 shadow-md">
-        {/* 
-          "РАБОЧАЯ ОБЛАСТЬ":
-          - h-[72px]: высота шапки
-          - pl-[10px]: отступ слева
-          - flex items-center: вертикальное выравнивание
-        */}
-        <div className="flex items-center pl-[10px]">
-          <a href="/">
-            {/* 
-              ЛОГОТИП:
-              - h-[30px]: высота SVG
-              - w-[100px]: ширина SVG
-              - text-brand-primary: цвет логотипа
-            */}
+      <header className="fixed top-0 left-0 right-0 z-50 w-full border-b border-gray-200 bg-gray-100 shadow-md">
+        <div className="mx-auto flex h-[72px] sm:h-[80px] lg:h-[96px] items-center justify-between px-4">
+          <a href="/" aria-label="На главную" className="flex-shrink-0">
             <Logo className="h-[30px] w-auto" style={{ color: "var(--color-brand-primary)" }} />
           </a>
+          <nav className="hidden lg:flex items-center gap-x-6">
+            {NAV_LINKS.map((link) => (
+              <a key={link.href} href={link.href} className="text-text-primary hover:text-brand-primary">
+                {link.label}
+              </a>
+            ))}
+          </nav>
+          <button className="lg:hidden p-2" data-open-menu>
+            <BurgerIcon className="h-6 w-6 text-text-primary" />
+          </button>
         </div>
       </header>
-      {/* Отступ для контента, чтобы учесть высоту шапки */}
-      <div className="h-[72px] bg-gray-100" />
+      <div className="h-[72px] sm:h-[80px] lg:h-[96px] bg-gray-100" />
+
+      <div className="fixed inset-0 z-40 hidden bg-white" data-mobile-menu>
+        <div className="flex h-full flex-col">
+          <div className="flex items-center justify-between px-4 h-[72px]">
+            <Logo className="h-[30px] w-auto" style={{ color: "var(--color-brand-primary)" }} />
+            <button className="p-2" data-close-menu>
+              <CloseIcon className="h-6 w-6 text-text-primary" />
+            </button>
+          </div>
+          <nav className="flex flex-col items-start px-4 space-y-4 mt-4">
+            {NAV_LINKS.map((link) => (
+              <a key={link.href} href={link.href} className="text-lg text-text-primary">
+                {link.label}
+              </a>
+            ))}
+          </nav>
+        </div>
+      </div>
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `(() => {
+            var menu = document.querySelector('[data-mobile-menu]');
+            var openBtn = document.querySelector('[data-open-menu]');
+            var closeBtn = menu && menu.querySelector('[data-close-menu]');
+            if (openBtn && menu) {
+              openBtn.addEventListener('click', () => menu.classList.remove('hidden'));
+            }
+            if (closeBtn && menu) {
+              closeBtn.addEventListener('click', () => menu.classList.add('hidden'));
+            }
+          })();`,
+        }}
+      />
     </>
   );
 }

--- a/packages/ui/src/SimpleSwiper.tsx
+++ b/packages/ui/src/SimpleSwiper.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+interface SimpleSwiperProps {
+  slides: string[];
+}
+
+export default function SimpleSwiper({ slides }: SimpleSwiperProps) {
+  return (
+    <div className="relative overflow-hidden" data-simple-swiper>
+      <div className="flex transition-transform duration-500" data-track>
+        {slides.map((text, i) => (
+          <div
+            key={i}
+            className="min-w-full bg-gray-200 flex items-center justify-center py-10"
+          >
+            <p className="text-xl font-bold text-text-primary">{text}</p>
+          </div>
+        ))}
+      </div>
+      <button
+        className="absolute left-2 top-1/2 -translate-y-1/2 bg-white/70 px-2 py-1"
+        data-prev
+      >
+        ‹
+      </button>
+      <button
+        className="absolute right-2 top-1/2 -translate-y-1/2 bg-white/70 px-2 py-1"
+        data-next
+      >
+        ›
+      </button>
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `(function(){var c=document.currentScript.parentElement;var t=c.querySelector('[data-track]');var s=t.children;var i=0;function u(){t.style.transform='translateX('+(i*-100)+'%')};c.querySelector('[data-next]').addEventListener('click',function(){i=(i+1)%s.length;u()});c.querySelector('[data-prev]').addEventListener('click',function(){i=(i-1+s.length)%s.length;u()});})();`,
+        }}
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,3 +1,4 @@
 export { default as Header } from "./Header";
 export { default as ProductCard } from "./ProductCard";
 export { default as CatalogContent } from "./CatalogContent";
+export { default as SimpleSwiper } from "./SimpleSwiper";


### PR DESCRIPTION
## Summary
- make `Header` responsive and include simple mobile menu toggle
- implement `SimpleSwiper` component for demo slides
- export `SimpleSwiper` in ui package
- render `SimpleSwiper` in `PageRenderer`
- add swiper instance to the Kyanchir homepage config

## Testing
- `npx tsc -p backend/tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68837ab4ec488324ba7ef763588bd139