### PR TITLE
Fix kyanchir build path

### DIFF
--- a/apps/kyanchir/tsconfig.json
+++ b/apps/kyanchir/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "dist",
-    "rootDir": ".",
+    "rootDir": "src",
     "jsx": "react-jsx",
     "lib": [
       "ES2020",


### PR DESCRIPTION
## Summary
- ensure Kyanchir emits server.js directly in `dist`

## Testing
- `npx tsc -p backend/tsconfig.json --noEmit`
- `pnpm dev` *(fails: command exited because I interrupted to end the watchers)*

------
https://chatgpt.com/codex/tasks/task_e_6886e29064b08324ba66d3d777d18445