### PR TITLE
Fix avatar upload auth and site disable check

### DIFF
--- a/admin/src/pages/Users.tsx
+++ b/admin/src/pages/Users.tsx
@@ -120,8 +120,10 @@ export default function UsersPage() {
     const formData = new FormData();
     formData.append("file", file);
 
+    const token = localStorage.getItem("token");
     const res = await fetch("http://localhost:3001/api/upload", {
       method: "POST",
+      headers: token ? { Authorization: `Bearer ${token}` } : undefined,
       body: formData,
     });
 

--- a/apps/kyanchir/src/server.ts
+++ b/apps/kyanchir/src/server.ts
@@ -12,8 +12,28 @@ const app = express();
 app.use(express.static("public"));
 const PORT = 4000;
 
+// Путь к файлу с данными сайтов backend
+const sitesFilePath = path.resolve(__dirname, "../../backend/db/sites.json");
+const SITE_ID = process.env.SITE_ID || "kyanchir-site-id";
+
+function isSiteActive(): boolean {
+  try {
+    const sites = JSON.parse(fs.readFileSync(sitesFilePath, "utf-8"));
+    const site = sites.find((s: any) => s.id === SITE_ID);
+    return site?.status === "active";
+  } catch (e) {
+    console.error("Не удалось прочитать статус сайта:", e);
+    return true; // по умолчанию считаем сайт активным
+  }
+}
+
 app.get("*", (req, res) => {
   try {
+    if (!isSiteActive()) {
+      return res
+        .status(503)
+        .send("<h1>Сайт временно отключен администратором</h1>");
+    }
     const html = ReactDOMServer.renderToString(
       React.createElement(PageRenderer)
     );


### PR DESCRIPTION
## Summary
- fix missing Authorization header when uploading avatars
- allow client site to check site status from backend database

## Testing
- `npx tsc -p backend/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6886ff447db483249305977973faf7d3